### PR TITLE
Adding docstyle checking to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,4 +20,4 @@ repos:
         exclude: tests
         args:
           - --convention=google
-          - --add-ignore=D100,D104,D200
+          - --add-ignore=D100,D104,D212,D200,D415

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,9 +5,19 @@ repos:
     - id: black
       args: [--safe]
       language_version: python3
+
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.1.0
     hooks:
     - id: flake8
       args: ['--max-line-length=88', '--select=W291,W292,W293,F401']
       language_version: python3
+
+-   repo: https://github.com/pycqa/pydocstyle
+    rev: 6.3.0
+    hooks:
+      - id: pydocstyle
+        exclude: tests
+        args:
+          - --convention=google
+          - --add-ignore=D100,D104,D200

--- a/src/template/__init__.py
+++ b/src/template/__init__.py
@@ -12,6 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+
 def example(a, b):
     """
     This is an example function that add the values of a and b


### PR DESCRIPTION
This will ensure a consistent documentation style is used throughout the Franklin. 

Google is suggested as the committer's belief that it is the clearest and easy to parse. 

The conventions ignored are:

D100	Missing docstring in public module
D104      Missing docstring in public package
D200	One-line docstring should fit on one line with quotes

The reasoning for D100 and D104 is that often; these doc strings are beyond self-evident from the naming of the class or module. For D200, this is not always the case, especially if we are stating the max line length is 88.